### PR TITLE
fix for #6

### DIFF
--- a/lib/text-editor-facade.js
+++ b/lib/text-editor-facade.js
@@ -24,7 +24,7 @@ export default class TextEditorFacade {
 
     isElmFile() {
         const fileName = this.getFileName();
-        const lastFourCharsOfFileName = fileName.substr(fileName.length - 4);
+        const lastFourCharsOfFileName = (fileName) ? fileName.substr(fileName.length - 4) : "";
         return lastFourCharsOfFileName === ".elm";
     }
 


### PR DESCRIPTION
Elm file detection on editor window was blowing up the plugin if there was no file associated with the editor